### PR TITLE
[Fix] Call to a member function getDownloadURL() on null

### DIFF
--- a/manual_nav/blocks/manual_nav/controller.php
+++ b/manual_nav/blocks/manual_nav/controller.php
@@ -115,8 +115,10 @@ class Controller extends BlockController
                 $q['collectionName'] = $lc->getCollectionName();
             } elseif (!$q['linkURL'] && $q['internalLinkFID']) {
                 $file = File::getByID((int) $q['internalLinkFID']);
-                $q['linkURL'] = $file->getDownloadURL();
-                $q['collectionName'] = $file->getFileName();
+                if (is_object($file)) {
+                    $q['linkURL'] = $file->getDownloadURL();
+                    $q['collectionName'] = $file->getFileName();
+                }
             }
 
             //image type


### PR DESCRIPTION
This PR fixes the exception when an attached file got deleted.