### PR TITLE
form_setup_html.phpで属性の重複している要素が存在します

### DIFF
--- a/manual_nav/blocks/manual_nav/form_setup_html.php
+++ b/manual_nav/blocks/manual_nav/form_setup_html.php
@@ -323,7 +323,7 @@ if ($rows) {
                 </div>
             </div>
 
-            <div class="checkbox" style="display: none;" data-field="entry-link-blank-window" class="form-group">
+            <div style="display: none;" data-field="entry-link-blank-window" class="form-group">
                 <label>
                     <input type="hidden" name="openInNewWindow[]" value="<% if(openInNewWindow==1){ %>1<% }else{ %>0 <% } %>"/>
                     <input type="checkbox" <% if(openInNewWindow==1){ %>checked <% } %> name="openInNewWindowCheck[<%=sort_order%>]" value="1"  />


### PR DESCRIPTION
はじめまして、こちらのアドオンをよく利用させて頂いてます！

下記の内容でプルリクいたしました。

## 内容

```
<div class="checkbox" style="display: none;" data-field="entry-link-blank-window" class="form-group">
```
を
```
<div style="display: none;" data-field="entry-link-blank-window" class="form-group">
```
に修正しました。

他の要素に合わせて、 `form-group` のクラスが正しいだろうとみました。

ご確認頂けますと幸いです。
よろしくおねがいします。